### PR TITLE
Fix `g3.load_lat_lon_range` for float lat/lon ranges (vs. integers)

### DIFF
--- a/gesla.py
+++ b/gesla.py
@@ -156,7 +156,7 @@ class GeslaDataset:
         Returns:
             xarray.Dataset: data, flags, and metadata for each record.
         """
-        if west_lon > 0 & east_lon < 0:
+        if (west_lon > 0) & (east_lon < 0):
             lon_bool = (self.meta.longitude >= west_lon) | (
                 self.meta.longitude <= east_lon
             )


### PR DESCRIPTION
Currently, the `g3.load_lat_lon_range` function fails if coordinates are passed in as floats rather than integers, as the lack of brackets at line 159 causes these tests to be evaluated in the wrong order:
```
south_lat = -43.0
north_lat = -10.0
west_lon = 113.0
east_lon = 153.0


data = g3.load_lat_lon_range(
    south_lat=south_lat,
    north_lat=north_lat,
    west_lon=west_lon,
    east_lon=east_lon,
)
print(data.site_name.values)
```

> ---------------------------------------------------------------------------
> TypeError                                 Traceback (most recent call last)
> Cell In[2], line 7
>       3 west_lon = 113.0
>       4 east_lon = 153.0
> ----> 7 data = g3.load_lat_lon_range(
>       8     south_lat=south_lat,
>       9     north_lat=north_lat,
>      10     west_lon=west_lon,
>      11     east_lon=east_lon,
>      12 )
>      13 print(data.site_name.values)
> 
> File /gdata1/data/sea_level/GeslaDataset/gesla.py:159, in GeslaDataset.load_lat_lon_range(self, south_lat, north_lat, west_lon, east_lon, force_xarray)
>     129 def load_lat_lon_range(
>     130     self,
>     131     south_lat=-90,
>    (...)
>     135     force_xarray=False,
>     136 ):
>     137     """Load GESLA records within a rectangular lat/lon range into a xarray.
>     138     Dataset object.
>     139 
>    (...)
>     157         xarray.Dataset: data, flags, and metadata for each record.
>     158     """
> --> 159     if west_lon > 0 & east_lon < 0:
>     160         lon_bool = (self.meta.longitude >= west_lon) | (
>     161             self.meta.longitude <= east_lon
>     162         )
>     163     else:
> 
> TypeError: unsupported operand type(s) for &: 'int' and 'float'

This PR resolves this issue by adding in brackets to ensure that both tests are applied in their correct order of operations, avoiding a situation where a Float is compared directly via `&`.